### PR TITLE
Add replace existing filter widget

### DIFF
--- a/crud-manager/template.stache
+++ b/crud-manager/template.stache
@@ -88,11 +88,9 @@
       {{/if}}
     </div>
 
-    {{#if filterVisible}}
-      <panel-container>
+      <panel-container class="{{^filterVisible}}hidden{{/filterVisible}}">
         <filter-widget {(filters)}="parameters.filters" {fields}="_fields" {object-template}="view.objectTemplate" />
       </panel-container>
-    {{/if}}
 
     {{#if showPaginate}}
       <div class="hidden-print">

--- a/filter-widget/filter-widget.js
+++ b/filter-widget/filter-widget.js
@@ -220,6 +220,16 @@ export let ViewModel = CanMap.extend({
           };
         }) : null;
       }
+    },
+    /**
+     * If true, existing filters will be replaced rather than concatenated
+     * when the addFilter method is called
+     * @property {Boolean} filter-widget.ViewModel.replaceExisting
+     * @parent filter-widget.ViewModel.props
+     */
+    replaceExisting: {
+      value: false,
+      type: 'boolean'
     }
   },
   /**
@@ -280,14 +290,20 @@ export let ViewModel = CanMap.extend({
       filters = [obj];
     }
 
-    //start batch process
-    can.batch.start();
-    filters.forEach(f => {
-      this.attr('filters').push(f);
-    });
-    this.attr('formObject', null);
-    //end batch process
-    can.batch.stop();
+    if (this.attr('replaceExisting')) {
+      this.attr('filters').replace(filters);
+    } else {
+
+      //start batch process
+      //concat array doesn't seem to update correctly
+      can.batch.start();
+      filters.forEach(f => {
+        this.attr('filters').push(f);
+      });
+      this.attr('formObject', null);
+      //end batch process
+      can.batch.stop();
+    }
 
     return false;
   }

--- a/filter-widget/filter-widget.test.js
+++ b/filter-widget/filter-widget.test.js
@@ -94,6 +94,16 @@ test('addFilter()', assert => {
   assert.equal(vm.attr('filters').length, 1, 'filters should been added');
 });
 
+test('addFilter() with replaceExisting', assert => {
+  vm.addFilter(null, null, null, filter);
+  vm.addFilter(null, null, null, filter);
+  assert.equal(vm.attr('filters').length, 2, 'filters should been added');
+
+  vm.attr('replaceExisting', true);
+  vm.addFilter(null, null, null, filter);
+  assert.equal(vm.attr('filters').length, 1, 'filters should been replaced');
+});
+
 test('addFilter() with filterFactory', assert => {
   vm.attr('fields', [{
     name: 'test',

--- a/filter-widget/template.stache
+++ b/filter-widget/template.stache
@@ -1,7 +1,13 @@
 <div class="filter-widget container-fluid">
   <h4>Add Filter</h4>
-  <form-widget inline="true" {fields}="formFields" {(form-object)}="formObject" (submit)="addFilter" />
 
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" {($checked)}="replaceExisting"> Replace existing filters
+    </label>
+  </div>
+  
+  <form-widget inline="true" {fields}="formFields" {(form-object)}="formObject" (submit)="addFilter" />
   {{#if filters.length}}
     <h4>Current Filters
       <button class="btn btn-default" ($click)="removeFilters">

--- a/list-table/list-table.js
+++ b/list-table/list-table.js
@@ -156,7 +156,6 @@ export const ViewModel = CanMap.extend({
    * @signature
    */
   toggleSelectAll() {
-    console.log(arguments);
     if (this.attr('selectedObjects').length < this.attr('objects').length) {
       this.attr('selectedObjects').replace(this.attr('objects'));
     } else {


### PR DESCRIPTION
Adds a new property `replaceExisting` which upon adding a new filter, it will instead replace the existing filter with the new one.
