### PR TITLE
Utilizes the define plugin's properties to create fields.

### DIFF
--- a/filter-widget/Filter.js
+++ b/filter-widget/Filter.js
@@ -78,7 +78,7 @@ export const FilterOptions = [{
   valueField: {
     name: 'value',
     alias: 'Value',
-    type: 'date',
+    fieldType: 'date',
     properties: {
       placeholder: 'Select a date'
     }
@@ -90,7 +90,7 @@ export const FilterOptions = [{
   valueField: {
     name: 'value',
     alias: 'Value',
-    type: 'date',
+    fieldType: 'date',
     properties: {
       placeholder: 'Select a date'
     }

--- a/filter-widget/filter-widget.js
+++ b/filter-widget/filter-widget.js
@@ -140,7 +140,7 @@ export let ViewModel = CanMap.extend({
         let defaultField = {
           name: 'value',
           alias: 'Value',
-          type: 'text',
+          fieldType: 'text',
           properties: {
             placeholder: 'Enter a filter value'
           }

--- a/filter-widget/filter-widget.js
+++ b/filter-widget/filter-widget.js
@@ -103,7 +103,7 @@ export let ViewModel = CanMap.extend({
           formatter: makeSentenceCase,
           name: 'name',
           alias: 'Field Name',
-          type: 'select',
+          fieldType: 'select',
           properties: {
             options: this.attr('fieldOptions')
           }
@@ -116,7 +116,7 @@ export let ViewModel = CanMap.extend({
           name: 'operator',
           alias: 'is',
           placeholder: 'Choose an operator',
-          type: 'select',
+          fieldType: 'select',
           formatter(op) {
             return FilterOptions.filter(f => {
               return f.value === op;
@@ -153,7 +153,7 @@ export let ViewModel = CanMap.extend({
     /**
      * A getter for the filter operators that changes based on the selected field and
      * the selected field's type. The value may be filtered based on
-     * 1. If there is a `dataType` property on the field that matches the name of the dropdown
+     * 1. If there is a `type` property on the field that matches the name of the dropdown
      * 2. 2f there is a defined type in the define property for the current filter field dropdown
      * If a type is found using the rules above, the returned value will be filtered to only include
      * operators for the given type.
@@ -166,15 +166,15 @@ export let ViewModel = CanMap.extend({
         let name = this.attr('formObject.name');
         let fields = this.attr('fields');
 
-        //if we have fields search them for a dataType matching the name
+        //if we have fields search them for a type matching the name
         //of the selected field name
         if (fields) {
           let field = fields.filter(f => {
             return f.attr('name') === name;
           })[0];
-          if (field && field.attr('dataType')) {
+          if (field && field.attr('type')) {
             return FilterOptions.filter(f => {
-              return f.types.indexOf(field.attr('dataType')) !== -1;
+              return f.types.indexOf(field.attr('type')) !== -1;
             });
           }
         }

--- a/filter-widget/filter-widget.test.js
+++ b/filter-widget/filter-widget.test.js
@@ -37,23 +37,24 @@ test('formObject get()', assert => {
 });
 
 test('formFields get()', assert => {
-  assert.equal(vm.attr('formFields')[0].type, 'text', 'name field type should be text by default');
+  assert.equal(vm.attr('formFields')[0].fieldType, 'text', 'name field fieldType should be text by default');
 
   let field = {
     name: 'test',
     alias: 'Test'
   };
   vm.attr('fields', [field]);
-  assert.equal(vm.attr('formFields')[0].type, 'select', 'name field type should be select when there are fieldOptions');
+  assert.equal(vm.attr('formFields')[0].fieldType, 'select', 'name field fieldType should be select when there are fieldOptions');
 });
 
 test('valueField get()', assert => {
-  assert.equal(vm.attr('valueField').type, 'text', 'default valueField type should be text');
+  console.log(vm.attr('valueField'));
+  assert.equal(vm.attr('valueField').fieldType, 'text', 'default valueField fieldType should be text');
 
   let obj = vm.attr('formObject');
   obj.attr('operator', 'after');
   vm.attr('formObject', obj);
-  assert.equal(vm.attr('valueField').type, 'date', 'when using a date operator, valueField type should be date');
+  assert.equal(vm.attr('valueField').fieldType, 'date', 'when using a date operator, valueField fieldType should be date');
 });
 
 test('filterOptions get()', assert => {
@@ -61,9 +62,9 @@ test('filterOptions get()', assert => {
   obj.attr('name', 'test');
   vm.attr('formObject', obj);
 
-  vm.attr('fields', [{name: 'test', label: 'test', dataType: 'date'}]);
+  vm.attr('fields', [{name: 'test', label: 'test', type: 'date'}]);
   vm.attr('filterOptions').forEach(f => {
-    assert.ok(f.types.indexOf('date') !== -1 , 'each filter should have type date');
+    assert.ok(f.types.indexOf('date') !== -1 , 'each filter should have fieldType date');
   });
 
 

--- a/util/field.js
+++ b/util/field.js
@@ -59,7 +59,7 @@ export const Field = CanMap.extend({
      * are defined in the `util/field.TEMPLATES` constant
      * @property {String} util/field.Field.type
      */
-    type: {
+    fieldType: {
       type: 'string',
       value: 'text'
     },
@@ -74,7 +74,7 @@ export const Field = CanMap.extend({
         if (template) {
           return template;
         }
-        let type = this.attr('type');
+        let type = this.attr('fieldType');
         if (!TEMPLATES.hasOwnProperty(type)) {
           console.warn('No template for the given field type', type);
           return TEMPLATES.text;
@@ -103,6 +103,10 @@ export const Field = CanMap.extend({
     excludeForm: {
       value: false
     },
+    /**
+     * Formats the property when it is displayed in a property or list table
+     * @property {Function}
+     */
     formatter: {
       value: null
     }
@@ -125,17 +129,13 @@ export function mapToFields(m) {
   let define = m.define || m.prototype.define;
   let fields = [];
   if (define) {
-    let defineTypes = {
-      string: 'text',
-      date: 'date',
-      number: 'text'
-    };
     for (let prop in define) {
       if (define.hasOwnProperty(prop)) {
-        fields.push({
+        fields.push(can.extend({
           name: prop,
-          type: defineTypes[define[prop].type] || 'text'
-        });
+          type: 'text',
+          fieldType: 'text',
+        }, define[prop]));
       }
     }
   } else {

--- a/util/field.js
+++ b/util/field.js
@@ -133,7 +133,7 @@ export function mapToFields(m) {
       if (define.hasOwnProperty(prop)) {
         fields.push(can.extend({
           name: prop,
-          type: 'text',
+          type: 'string',
           fieldType: 'text',
         }, define[prop]));
       }

--- a/util/field.test.js
+++ b/util/field.test.js
@@ -7,7 +7,7 @@ let cases = [{
   name: 'one'
 }, {
   name: 'two',
-  type: 'date'
+  fieldType: 'date'
 }, {
   name: 'three',
   alias: 'Custom'
@@ -31,5 +31,5 @@ q.module('.ViewModel', {
 });
 
 test('Field.alias default', assert => {
-  
+
 });


### PR DESCRIPTION
- Fixes https://github.com/roemhildtg/can-crud/issues/16
- Causes API changes to the field properties
- `dataType` changes to the default define plugin's `type`
- `type` changes to `fieldType`
