### PR TITLE
Rename all page to list

### DIFF
--- a/crud-manager/crud-manager.js
+++ b/crud-manager/crud-manager.js
@@ -86,7 +86,6 @@ export let ViewModel = CanMap.extend({
     view: {
       Type: ViewMap,
       set(view) {
-
         //if parameters are in the view, mix them in to the crud parameters
         if (view.attr('parameters')) {
           this.attr('parameters').attr(view.attr('parameters').serialize());
@@ -96,14 +95,14 @@ export let ViewModel = CanMap.extend({
     },
     /**
      * The current page to display in this view. Options include:
-     * * `all`: The list table page that displays all records
+     * * `list`: The list table page that displays all records
      * * `details`: The individual view page that shows one detailed record
      * * `edit`: The editing view that allows editing of an individual record using a form
      * @property {String} crud-manager.ViewModel.props.page
      * @parent crud-manager.ViewModel.props
      */
     page: {
-      value: 'all',
+      value: 'list',
       type: 'string'
     },
     /**

--- a/crud-manager/crud-manager.test.js
+++ b/crud-manager/crud-manager.test.js
@@ -233,8 +233,8 @@ test('setPage(page)', assert => {
     viewId: 999
   });
 
-  vm.setPage('all');
-  assert.equal(vm.attr('page'), 'all', 'page should be set correctly');
+  vm.setPage('list');
+  assert.equal(vm.attr('page'), 'list', 'page should be set correctly');
   assert.equal(vm.attr('viewId'), 0, 'viewId should be reset');
 });
 

--- a/crud-manager/template.stache
+++ b/crud-manager/template.stache
@@ -6,7 +6,7 @@
       <p>You do not have permission to edit this data.</p>
     {{else}}
       {{#if focusObject.isResolved}}
-        <form-widget {form-object}="focusObject.value" (submit)="saveObject" (cancel)="setPage('all')"
+        <form-widget {form-object}="focusObject.value" (submit)="saveObject" (cancel)="setPage('list')"
           {fields}="_fields" />
       {{/if}}
     {{/if}}
@@ -20,7 +20,7 @@
     {{#if view.disableAdd}}
       <p>You do not have permission to add this data.</p>
     {{else}}
-      <form-widget {form-object}="getNewObject()" (submit)="saveObject" (cancel)="setPage('all')"
+      <form-widget {form-object}="getNewObject()" (submit)="saveObject" (cancel)="setPage('list')"
         {fields}="_fields" />
     {{/if}}
 
@@ -30,7 +30,7 @@
 
 
 
-  {{#case 'all'}}
+  {{#case 'list'}}
     {{#if objects.isPending}}
       <div class="progress">
         <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="100"
@@ -131,7 +131,7 @@
     {{#if focusObject.isResolved}}
       <property-table {object}="focusObject.value" {fields}="_fields" />
       <div class="btn btn-group hidden-print" role="group" aria-label="Management Buttons">
-        <button class="btn btn-default" ($click)="setPage('all')">
+        <button class="btn btn-default" ($click)="setPage('list')">
           <i class="fa fa-arrow-left"></i> Back
         </button>
         {{#unless view.disableEdit}}
@@ -159,7 +159,7 @@
 
 
   {{#case 'selection'}}
-    <button class="btn btn-default" ($click)="setPage('all')">
+    <button class="btn btn-default" ($click)="setPage('list')">
       <i class="fa fa-arrow-left"></i> Back
     </button>
     {{#if selectedObjects.length}}


### PR DESCRIPTION
Renames the "all" page to "list" to better describe the view. 

"list" page - shows all the items in a list format
"details" page - shows one item with details 
...etc. 

List is a much more appropriate description than "all"
